### PR TITLE
Task 7: Authorization

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -7,8 +7,16 @@ import PageProductImport from "~/components/pages/admin/PageProductImport/PagePr
 import PageCart from "~/components/pages/PageCart/PageCart";
 import PageProducts from "~/components/pages/PageProducts/PageProducts";
 import { Typography } from "@mui/material";
+import { useEffect } from "react";
 
 function App() {
+  useEffect(() => {
+    localStorage.setItem(
+      "authorization_token",
+      "dGFydW5iaGFydGl5YTc6VEVTVF9QQVNTV09SRA=="
+    );
+  }, []);
+
   return (
     <MainLayout>
       <Routes>

--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -34,6 +34,9 @@ export default function CSVFileImport({ url, title }: CSVFileImportProps) {
         params: {
           name: encodeURIComponent(file.name),
         },
+        headers: {
+          Authorization: `Basic ${localStorage.getItem("authorization_token")}`,
+        },
       });
       console.log("File to upload: ", file.name);
       console.log("Uploading to: ", response.data.url);


### PR DESCRIPTION
Following tasks are completed:
- authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
- Import Service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
- Client application is updated to send "Authorization: Basic authorization_token" header on import. Client should get authorization_token value from browser localStorage

CloudFront URL: https://d1rxysx81o0hyh.cloudfront.net/

<img width="1434" alt="Screenshot 2022-11-15 at 8 23 39 AM" src="https://user-images.githubusercontent.com/20270023/201920832-8aed7143-272b-440b-897b-5aa48b092580.png">

<img width="1420" alt="Screenshot 2022-11-15 at 8 23 01 AM" src="https://user-images.githubusercontent.com/20270023/201920868-f1ad1fe0-b765-4198-9bd8-d0451947a43e.png">

<img width="1431" alt="Screenshot 2022-11-15 at 8 24 25 AM" src="https://user-images.githubusercontent.com/20270023/201920905-f9fc263b-155e-4422-9b86-a08d4a3c19d2.png">

